### PR TITLE
Fix docs references and license note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RTD-Based Reservoir Computing for ECG Signal Simulation
 
-> ⚠️ **This repository contains unpublished academic research and is not authorized for redistribution or reuse.**
+> ⚠️ **This repository contains academic research code provided under the [MIT License](LICENSE).**
 
 ## 🧠 Project Overview
 
@@ -70,7 +70,6 @@ $$
 | **MAE**      | 0.0453   |
 | **RMSE**     | 0.0724   |
 
-<!-- Screenshot removed: original image referenced a missing docs directory -->
 
 
 ## 🖥️ GUI Interface (Streamlit)


### PR DESCRIPTION
## Summary
- fix README license wording
- remove stray screenshot comment

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68463f20f2c08331b2c8b38cfc681f93