### PR TITLE
Ensure save_simulation_video creates output directory

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,6 @@
 # utils.py
 from matplotlib import pyplot as plt
+import os
 
 
 def plot_ecg_prediction(true_vals, predicted_vals):
@@ -10,13 +11,13 @@ def plot_ecg_prediction(true_vals, predicted_vals):
     ax.set_title("ECG Signal Prediction")
     return fig
 
-def save_simulation_video(true_vals, predicted_vals, filename='output/simulation.mp4'):
+def save_simulation_video(true_vals, predicted_vals, filename="output/simulation.mp4"):
     import matplotlib.animation as animation
     fig, ax = plt.subplots()
     ax.set_xlim(0, len(predicted_vals))
     ax.set_ylim(min(true_vals), max(true_vals))
-    line1, = ax.plot([], [], lw=2, label='True')
-    line2, = ax.plot([], [], lw=2, label='Predicted')
+    line1, = ax.plot([], [], lw=2, label="True")
+    line2, = ax.plot([], [], lw=2, label="Predicted")
     ax.legend()
 
     def update(i):
@@ -25,5 +26,6 @@ def save_simulation_video(true_vals, predicted_vals, filename='output/simulation
         return line1, line2
 
     ani = animation.FuncAnimation(fig, update, frames=len(predicted_vals), blit=True)
-    ani.save(filename, fps=30, extra_args=['-vcodec', 'libx264'])
+    os.makedirs(os.path.dirname(filename), exist_ok=True)
+    ani.save(filename, fps=30, extra_args=["-vcodec", "libx264"])
     return filename


### PR DESCRIPTION
## Summary
- make sure the video output directory exists before saving
- add missing `os` import

## Testing
- `python3 -m py_compile utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68480610c23c8331b6dce11495807cc3